### PR TITLE
Add route for number of users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,6 @@ sketch
 docker-compose.yml
 
 # End of https://www.gitignore.io/api/react,django,python
+
+# pycharm settings
+.idea/

--- a/backend/apps/accounts/generate_users.py
+++ b/backend/apps/accounts/generate_users.py
@@ -61,12 +61,16 @@ from apps.iamstudent.models import Student, AUSBILDUNGS_TYPEN_COLUMNS
 from apps.accounts.models import User
 from django.http import HttpResponse
 
+from django.contrib.auth.decorators import login_required
+from .decorator import student_required, hospital_required
+from django.contrib.admin.views.decorators import staff_member_required
 
 
 def delete_fakes():
     User.objects.filter(email__contains='email').delete()
 
-
+@login_required
+@staff_member_required
 def populate_db(request):
     delete_fakes()
     n_student = 2000

--- a/backend/apps/accounts/urls.py
+++ b/backend/apps/accounts/urls.py
@@ -32,5 +32,6 @@ urlpatterns = [
     path('profile_student', views.edit_student_profile, name='edit_student_profile'),
     path('profile_hospital', views.edit_hospital_profile, name='edit_hospital_profile'),
     path('approve_hospitals', views.approve_hospitals, name='approve_hospitals'),
-    path('change_hospital_approval/<str:uuid>/', views.change_hospital_approval, name='change_hospital_approval')
+    path('change_hospital_approval/<str:uuid>/', views.change_hospital_approval, name='change_hospital_approval'),
+    path('count', views.UserCountView.as_view(), name='count'),
 ]

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -1,10 +1,13 @@
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.contrib.auth import login, logout
 from django.shortcuts import redirect
 from django.views.generic import CreateView
 
 
 from django.conf import settings
+from rest_framework.renderers import JSONRenderer
+from rest_framework.views import APIView
+
 from .forms import StudentSignUpForm, HospitalSignUpForm
 from .models import User
 from apps.ineedstudent.forms import HospitalFormInfoSignUp, HospitalFormEditProfile, HospitalFormInfoCreate
@@ -228,6 +231,18 @@ def validate_email(request):
         request.user.validated_email = True
         request.user.save()
     return HttpResponseRedirect("/mapview")
+
+class UserCountView(APIView):
+    """
+    A view that returns the count of active users.
+
+    Source: https://stackoverflow.com/questions/25151586/django-rest-framework-retrieving-object-count-from-a-model
+    """
+
+    def get(self, request, format=None):
+        user_count = User.objects.count()
+        content = {'user_count': user_count}
+        return JsonResponse(content)
 
 from django.contrib.auth.views import LoginView
 


### PR DESCRIPTION
First part of #193

@andyz02 you can call /accounts/count to get a JSON response with a dict with the key 'user_count'. Branch (`git checkout number-supporters` und `git checkout -b NAME` ) from [number-supporters](https://github.com/Baschdl/match4healthcare/tree/number-supporters) to implement the UI part.

DON'T MERGE before checking load on server (@feeds Can we create a high number of users now?)